### PR TITLE
Add contractURI() to SingleEditionMintable

### DIFF
--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -101,6 +101,40 @@ contract SharedNFTLogic is IPublicSharedMetadata {
             );
     }
 
+    /// Encodes contract level metadata into base64-data uri format
+    /// @dev see https://docs.opensea.io/docs/contract-level-metadata
+    /// @dev borrowed from https://github.com/ourzora/zora-drops-contracts/blob/main/src/utils/NFTMetadataRenderer.sol
+    function encodeContractURIJSON(
+        string memory name,
+        string memory description,
+        string memory imageURI,
+        uint256 royaltyBPS,
+        address royaltyRecipient
+    ) public pure returns (string memory) {
+        bytes memory imageSpace = bytes("");
+        if (bytes(imageURI).length > 0) {
+            imageSpace = abi.encodePacked('", "image": "', imageURI);
+        }
+        return
+            string(
+                encodeMetadataJSON(
+                    abi.encodePacked(
+                        '{"name": "',
+                        name,
+                        '", "description": "',
+                        description,
+                        // this is for opensea since they don't respect ERC2981 right now
+                        '", "seller_fee_basis_points": ',
+                        StringsUpgradeable.toString(royaltyBPS),
+                        ', "fee_recipient": "',
+                        StringsUpgradeable.toHexString(royaltyRecipient),
+                        imageSpace,
+                        '"}'
+                    )
+                )
+            );
+    }
+
     /// Encodes the argument json bytes into base64-data uri format
     /// @param json Raw json to base64 and turn into a data-uri
     function encodeMetadataJSON(bytes memory json)

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -330,6 +330,16 @@ contract SingleEditionMintable is
             );
     }
 
+    function contractURI() public view returns (string memory) {
+        return sharedNFTLogic.encodeContractURIJSON(
+            name(),
+            description,
+            imageUrl,
+            royaltyBPS,
+            owner()
+        );
+    }
+
     function supportsInterface(bytes4 interfaceId)
         public
         view

--- a/test/SingleEditionMintableTest.ts
+++ b/test/SingleEditionMintableTest.ts
@@ -9,6 +9,21 @@ import {
   SingleEditionMintable,
 } from "../typechain";
 
+function parseMetadataURI(uri: string): any {
+  const parsedURI = parseDataURI(uri);
+  if (!parsedURI) {
+    throw "No parsed uri";
+  }
+
+  expect(parsedURI.mimeType.type).to.equal("application");
+  expect(parsedURI.mimeType.subtype).to.equal("json");
+
+  // Check metadata from edition
+  const uriData = Buffer.from(parsedURI.body).toString("utf-8");
+  const metadata = JSON.parse(uriData);
+  return metadata;
+}
+
 describe("SingleEditionMintable", () => {
   let signer: SignerWithAddress;
   let signerAddress: string;
@@ -125,21 +140,7 @@ describe("SingleEditionMintable", () => {
         );
 
       const tokenURI = await minterContract.tokenURI(1);
-      console.log(tokenURI);
-      const parsedTokenURI = parseDataURI(tokenURI);
-      if (!parsedTokenURI) {
-        throw "No parsed token uri";
-      }
-
-      // Check metadata from edition
-      const uriData = Buffer.from(parsedTokenURI.body).toString("utf-8");
-      const metadata = JSON.parse(uriData);
-
-      expect(parsedTokenURI.mimeType.type).to.equal("application");
-      expect(parsedTokenURI.mimeType.subtype).to.equal("json");
-      // expect(parsedTokenURI.mimeType.parameters.get("charset")).to.equal(
-      //   "utf-8"
-      // );
+      const metadata = parseMetadataURI(tokenURI);
       expect(JSON.stringify(metadata)).to.equal(
         JSON.stringify({
           name: "Testing Token 1/10",
@@ -195,26 +196,12 @@ describe("SingleEditionMintable", () => {
       expect(await minterContract.totalSupply()).to.be.equal(2);
 
       const tokenURI = await minterContract.tokenURI(1);
-      const parsedTokenURI = parseDataURI(tokenURI);
-      if (!parsedTokenURI) {
-        throw "No parsed token uri";
-      }
-
       const tokenURI2 = await minterContract.tokenURI(2);
-      const parsedTokenURI2 = parseDataURI(tokenURI2);
+      const metadata = parseMetadataURI(tokenURI);
+      const metadata2 = parseMetadataURI(tokenURI2);
 
-      // Check metadata from edition
-      const uriData = Buffer.from(parsedTokenURI.body).toString("utf-8");
-      const metadata = JSON.parse(uriData);
-
-      const uriData2 = Buffer.from(parsedTokenURI2?.body || "").toString(
-        "utf-8"
-      );
-      const metadata2 = JSON.parse(uriData2);
       expect(metadata2.name).to.be.equal("Testing Token 2");
 
-      expect(parsedTokenURI.mimeType.type).to.equal("application");
-      expect(parsedTokenURI.mimeType.subtype).to.equal("json");
       expect(JSON.stringify(metadata)).to.equal(
         JSON.stringify({
           name: "Testing Token 1",
@@ -384,18 +371,8 @@ describe("SingleEditionMintable", () => {
       ).to.be.revertedWith("Sold out");
 
       const tokenURI = await minterContract.tokenURI(10);
-      const parsedTokenURI = parseDataURI(tokenURI);
-      if (!parsedTokenURI) {
-        throw "No parsed token uri";
-      }
+      const metadata = parseMetadataURI(tokenURI);
 
-      // Check metadata from edition
-      const uriData = Buffer.from(parsedTokenURI.body).toString("utf-8");
-      console.log({ tokenURI, uriData });
-      const metadata = JSON.parse(uriData);
-
-      expect(parsedTokenURI.mimeType.type).to.equal("application");
-      expect(parsedTokenURI.mimeType.subtype).to.equal("json");
       expect(JSON.stringify(metadata)).to.equal(
         JSON.stringify({
           name: "Testing Token 10/10",


### PR DESCRIPTION
See https://docs.opensea.io/docs/contract-level-metadata

Editions should now have creator earnings configured out of the box on opensea, as well as have a collection image if one was provided (collections that only have an `animation_url` and no `image_url` won't have one)