### PR TITLE
SingleEditionMintableCreator: change salt and return value

### DIFF
--- a/test/SingleEditionMintableTest.ts
+++ b/test/SingleEditionMintableTest.ts
@@ -114,6 +114,7 @@ describe("SingleEditionMintable", () => {
     // TODO(iain): check bps
     expect(await minterContract.owner()).to.be.equal(signerAddress);
   });
+
   describe("with an edition", () => {
     let signer1: SignerWithAddress;
     let minterContract: SingleEditionMintable;
@@ -167,6 +168,22 @@ describe("SingleEditionMintable", () => {
           properties: { number: 1, name: "Testing Token" },
         })
       );
+    });
+
+    it("can not create another edition with the same parameters", async () => {
+      const args = [
+        "Testing Token",
+        "TEST",
+        "This is a testing token for all",
+        "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        10,
+        10,
+      ];
+
+      await expect(createEdition(dynamicSketch, args)).to.be.revertedWith("ERC1167: create2 failed");
     });
 
     it("creates an unbounded edition", async () => {

--- a/test/SingleEditionPurchaseMintableTest.ts
+++ b/test/SingleEditionPurchaseMintableTest.ts
@@ -32,7 +32,23 @@ describe("SingleEditionMintable", () => {
   });
 
   it("purchases a edition", async () => {
-    await dynamicSketch.createEdition(
+    let createEdition = async function(factory: SingleEditionMintableCreator, args: any): Promise<SingleEditionMintable> {
+      // first simulate the call to get the output
+      // @ts-ignore
+      const editionAddress = await factory.callStatic.createEdition(...args);
+
+      // then actually call the function to create the edition
+      // @ts-ignore
+      await factory.createEdition(...args);
+
+      const edition = (await ethers.getContractAt(
+        "SingleEditionMintable",
+        editionAddress
+      )) as SingleEditionMintable;
+      return edition;
+    }
+
+    const minterContract = await createEdition(dynamicSketch, [
       "Testing Token",
       "TEST",
       "This is a testing token for all",
@@ -41,14 +57,8 @@ describe("SingleEditionMintable", () => {
       "",
       "0x0000000000000000000000000000000000000000000000000000000000000000",
       10,
-      10
-    );
-
-    const editionResult = await dynamicSketch.getEditionAtId(0);
-    const minterContract = (await ethers.getContractAt(
-      "SingleEditionMintable",
-      editionResult
-    )) as SingleEditionMintable;
+      10,
+    ]);
     expect(await minterContract.name()).to.be.equal("Testing Token");
     expect(await minterContract.symbol()).to.be.equal("TEST");
 


### PR DESCRIPTION
Instead of a counter, use a salt based on the address of the creator and some values that we consider as important identifiers of the edition.

Also return the address of the new edition instead of the id, it is more convenient for Solidity callers.