### PR TITLE
Streamline mint single

### DIFF
--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -151,19 +151,15 @@ contract Edition is
     function purchase() external payable returns (uint256) {
         require(salePrice > 0, "Not for sale");
         require(msg.value == salePrice, "Wrong price");
-        address[] memory toMint = new address[](1);
-        toMint[0] = msg.sender;
         emit EditionSold(salePrice, msg.sender);
-        return _mintEditions(toMint);
+        return _mintEdition(msg.sender);
     }
 
         /// @param to address to send the newly minted edition to
     /// @dev This mints one edition to the given address by an allowed minter on the edition instance.
     function mintEdition(address to) external override returns (uint256) {
         require(_isAllowedToMint(), "Needs to be an allowed minter");
-        address[] memory toMint = new address[](1);
-        toMint[0] = to;
-        return _mintEditions(toMint);
+        return _mintEdition(to);
     }
 
     /// @param recipients list of addresses to send the newly minted editions to
@@ -189,6 +185,19 @@ contract Edition is
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Private function to mint without any access checks
+    /// @return tokenId the id of the newly minted token
+    function _mintEdition(address recipient)
+        internal
+        returns (uint256 tokenId)
+    {
+        tokenId = atEditionId.current();
+        require(editionSize == 0 || tokenId <= editionSize, "Sold out");
+
+        _mint(recipient, tokenId);
+        atEditionId.increment();
+    }
+
+    /// @dev Private function to batch mint without any access checks
     function _mintEditions(address[] memory recipients)
         internal
         returns (uint256)

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -193,7 +193,7 @@ contract Edition is
         tokenId = atEditionId.current();
         require(editionSize == 0 || tokenId <= editionSize, "Sold out");
 
-        _mint(recipient, tokenId);
+        _safeMint(recipient, tokenId);
         atEditionId.increment();
     }
 
@@ -206,7 +206,7 @@ contract Edition is
         uint256 endAt = startAt + recipients.length - 1;
         require(editionSize == 0 || endAt <= editionSize, "Sold out");
         while (atEditionId.current() <= endAt) {
-            _mint(
+            _safeMint(
                 recipients[atEditionId.current() - startAt],
                 atEditionId.current()
             );


### PR DESCRIPTION
2 big changes!

- about 1.2k gas savings per invocation compared to routing everything through the batch mint function
- and use safeMint instead of mint to avoid accidentally sending NFTs to unsuspecting contracts