### PR TITLE
Abi cleanup optimizations

### DIFF
--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -161,7 +161,7 @@ contract Edition is
 
     /// @param recipients list of addresses to send the newly minted editions to
     /// @dev This mints multiple editions to the given list of addresses.
-    function mintEditions(address[] memory recipients)
+    function mintEditions(address[] calldata recipients)
         external
         override
         returns (uint256)
@@ -203,7 +203,7 @@ contract Edition is
     }
 
     /// @dev Private function to batch mint without any access checks
-    function _mintEditions(address[] memory recipients)
+    function _mintEditions(address[] calldata recipients)
         internal
         returns (uint256)
     {

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -251,19 +251,6 @@ contract Edition is
         return editionSize;
     }
 
-    /// @notice Get URIs for edition NFT
-    /// @return imageUrl, animationUrl
-    function getURIs()
-        public
-        view
-        returns (
-            string memory,
-            string memory
-        )
-    {
-        return (imageUrl, animationUrl);
-    }
-
     /// @notice Get royalty information for token
     /// @param _salePrice Sale price for the token
     function royaltyInfo(uint256, uint256 _salePrice)

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -205,25 +205,25 @@ contract Edition is
     /// @dev Private function to batch mint without any access checks
     function _mintEditions(address[] memory recipients)
         internal
-        returns (uint256 lastTokenId)
+        returns (uint256)
     {
-        unchecked {
-            uint256 n = recipients.length;
-            uint256 startingTokenId = totalSupply + 1;
-            lastTokenId = totalSupply + n;
+        uint256 n = recipients.length;
+        require(n > 0, "No recipients");
 
+        uint256 tokenId;
+
+        unchecked {
             for (uint256 i = 0; i < n; ) {
-                _safeMint(
-                    recipients[i],
-                    startingTokenId + i
-                );
+                tokenId = totalSupply + i + 1;
+                _safeMint(recipients[i], tokenId);
 
                 ++i;
             }
         }
 
         // only update storage outside of the loop
-        updateTotalSupply(lastTokenId);
+        updateTotalSupply(tokenId);
+        return tokenId;
     }
 
     /// @dev This helper function checks if the msg.sender is allowed to mint

--- a/contracts/interfaces/IEdition.sol
+++ b/contracts/interfaces/IEdition.sol
@@ -5,19 +5,15 @@ interface IEdition {
     event EditionSold(uint256 price, address owner);
     event PriceChanged(uint256 amount);
 
+    function animationUrl() external view returns (string memory);
+
     function burn(uint256 tokenId) external;
 
     function description() external view returns (string memory);
 
     function editionSize() external view returns (uint256);
 
-    function getURIs()
-        external
-        view
-        returns (
-            string memory,
-            string memory
-        );
+    function imageUrl() external view returns (string memory);
 
     function initialize(
         address _owner,

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -94,9 +94,8 @@ describe("Edition", () => {
     const minterContract = await createEdition(dynamicSketch, args);
     expect(await minterContract.name()).to.be.equal("Testing Token");
     expect(await minterContract.symbol()).to.be.equal("TEST");
-    const editionUris = await minterContract.getURIs();
-    expect(editionUris[0]).to.be.equal("");
-    expect(editionUris[1]).to.be.equal(
+    expect(await minterContract.imageUrl()).to.equal("");
+    expect(await minterContract.animationUrl()).to.equal(
       "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy"
     );
     expect(await minterContract.editionSize()).to.equal(10);
@@ -291,6 +290,7 @@ describe("Edition", () => {
       await expect(minterContract.mintEditions([signerAddress])).to.be.reverted;
       await expect(minterContract.mintEdition(signerAddress)).to.be.reverted;
     });
+
     it("returns interfaces correctly", async () => {
       // ERC2891 interface
       expect(await minterContract.supportsInterface("0x2a55205a")).to.be.true;
@@ -359,7 +359,9 @@ describe("Edition", () => {
         toAddresses.push(s3a);
       }
       await minterContract.mintEditions(toAddresses);
+      expect(await minterContract.totalSupply()).to.equal(300);
     });
+
     it("stops after editions are sold out", async () => {
       const [_, signer1] = await ethers.getSigners();
 

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -99,9 +99,9 @@ describe("Edition", () => {
     expect(editionUris[1]).to.be.equal(
       "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy"
     );
-    expect(await minterContract.editionSize()).to.be.equal(10);
+    expect(await minterContract.editionSize()).to.equal(10);
     // TODO(iain): check bps
-    expect(await minterContract.owner()).to.be.equal(signerAddress);
+    expect(await minterContract.owner()).to.equal(signerAddress);
   });
 
   describe("with an edition", () => {


### PR DESCRIPTION
- replace with totalSupply public uint256 (this makes deploying a little cheaper (we don't store atEditionId = 1), but the first mint a little more expensive)
- move "Sold out" checks to updateTotalSupply(uint256 _totalSupply) function
- optimize _mintEditions with unchecked math and a single storage update
- can't batch mint with empty recipients
- don't copy the recipients array to memory
- replace getURIs() with imageUrl() and animationUrl()