### PR TITLE
Add support for external URL

### DIFF
--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -41,6 +41,9 @@ contract Edition is
     // Image in the metadata
     string public imageUrl;
 
+    // URL that will appear below the asset's image on OpenSea
+    string public externalUrl;
+
     // Total size of edition that can be minted
     uint256 public editionSize;
 
@@ -137,6 +140,10 @@ contract Edition is
         animationUrl = _animationUrl;
     }
 
+    /// @notice Updates the external_url field in the metadata
+    function setExternalUrl(string calldata _externalUrl) public onlyOwner {
+        externalUrl = _externalUrl;
+    }
 
     /*//////////////////////////////////////////////////////////////
                    COLLECTOR / TOKEN OWNER FUNCTIONS
@@ -288,13 +295,14 @@ contract Edition is
     }
 
     function contractURI() public view returns (string memory) {
-        return sharedNFTLogic.encodeContractURIJSON(
-            name(),
-            description,
-            imageUrl,
-            royaltyBPS,
-            owner()
-        );
+        return sharedNFTLogic.encodeContractURIJSON({
+            name: name(),
+            description: description,
+            imageURI: imageUrl,
+            externalURL: externalUrl,
+            royaltyBPS: royaltyBPS,
+            royaltyRecipient: owner()
+        });
     }
 
     function supportsInterface(bytes4 interfaceId)

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -79,11 +79,11 @@ contract Edition is
     /// @param _royaltyBPS BPS of the royalty set on the contract. Can be 0 for no royalty.
     function initialize(
         address _owner,
-        string memory _name,
-        string memory _symbol,
-        string memory _description,
-        string memory _animationUrl,
-        string memory _imageUrl,
+        string calldata _name,
+        string calldata _symbol,
+        string calldata _description,
+        string calldata _animationUrl,
+        string calldata _imageUrl,
         uint256 _editionSize,
         uint256 _royaltyBPS
     ) public initializer override {
@@ -238,7 +238,7 @@ contract Edition is
     }
 
     /*//////////////////////////////////////////////////////////////
-                        METADATA FUNCTIONS
+                           METADATA FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
     /// Returns the number of editions left to mint (max_uint256 when open edition)

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -289,6 +289,7 @@ contract Edition is
                 description,
                 imageUrl,
                 animationUrl,
+                externalUrl,
                 tokenId,
                 editionSize
             );

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -105,9 +105,10 @@ contract SharedNFTLogic is IPublicSharedMetadata {
     /// @dev see https://docs.opensea.io/docs/contract-level-metadata
     /// @dev borrowed from https://github.com/ourzora/zora-drops-contracts/blob/main/src/utils/NFTMetadataRenderer.sol
     function encodeContractURIJSON(
-        string memory name,
-        string memory description,
-        string memory imageURI,
+        string calldata name,
+        string calldata description,
+        string calldata imageURI,
+        string calldata externalURL,
         uint256 royaltyBPS,
         address royaltyRecipient
     ) public pure returns (string memory) {
@@ -115,6 +116,12 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         if (bytes(imageURI).length > 0) {
             imageSpace = abi.encodePacked('", "image": "', imageURI);
         }
+
+        bytes memory externalURLSpace = bytes("");
+        if (bytes(externalURL).length > 0) {
+            externalURLSpace = abi.encodePacked('", "external_link": "', externalURL);
+        }
+
         return
             string(
                 encodeMetadataJSON(
@@ -129,6 +136,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                         ', "fee_recipient": "',
                         StringsUpgradeable.toHexString(royaltyRecipient),
                         imageSpace,
+                        externalURLSpace,
                         '"}'
                     )
                 )

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -43,6 +43,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         string calldata description,
         string calldata imageUrl,
         string calldata animationUrl,
+        string calldata externalUrl,
         uint256 tokenOfEdition,
         uint256 editionSize
     ) external pure returns (string memory) {
@@ -54,6 +55,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         string memory json = createMetadataJSON(
             name,
             description,
+            externalUrl,
             _tokenMediaData,
             tokenOfEdition,
             editionSize
@@ -70,6 +72,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
     function createMetadataJSON(
         string calldata name,
         string calldata description,
+        string calldata externalURL,
         string memory mediaData,
         uint256 tokenOfEdition,
         uint256 editionSize
@@ -81,6 +84,12 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                 numberToString(editionSize)
             );
         }
+
+        string memory externalURLText = "";
+        if (bytes(externalURL).length > 0) {
+            externalURLText = string.concat('", "external_url": "', externalURL);
+        }
+
         return
             string.concat(
                 '{"name": "',
@@ -91,6 +100,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                 '", "',
                 'description": "',
                 description,
+                externalURLText,
                 '", "',
                 mediaData,
                 'properties": {"number": ',
@@ -170,7 +180,6 @@ contract SharedNFTLogic is IPublicSharedMetadata {
 
         if (hasImage) {
             buffer = string.concat(
-                buffer,
                 'image": "', imageUrl,
                 "?id=", numberToString(tokenOfEdition),
                 '", "'

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -166,32 +166,26 @@ contract SharedNFTLogic is IPublicSharedMetadata {
     ) public pure returns (string memory) {
         bool hasImage = bytes(imageUrl).length > 0;
         bool hasAnimation = bytes(animationUrl).length > 0;
-        if (hasImage && hasAnimation) {
-            return string.concat(
-                'image": "', imageUrl,
-                "?id=", numberToString(tokenOfEdition),
-                '", "animation_url": "', animationUrl,
-                "?id=", numberToString(tokenOfEdition),
-                '", "'
-            );
-        }
+        string memory buffer = "";
+
         if (hasImage) {
-            return string.concat(
+            buffer = string.concat(
+                buffer,
                 'image": "', imageUrl,
                 "?id=", numberToString(tokenOfEdition),
-                '", "'
-            );
-        }
-        if (hasAnimation) {
-            return string.concat(
-                'animation_url": "',
-                animationUrl,
-                "?id=",
-                numberToString(tokenOfEdition),
                 '", "'
             );
         }
 
-        return "";
+        if (hasAnimation) {
+            buffer = string.concat(
+                buffer,
+                'animation_url": "', animationUrl,
+                "?id=", numberToString(tokenOfEdition),
+                '", "'
+            );
+        }
+
+        return buffer;
     }
 }

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -39,10 +39,10 @@ contract SharedNFTLogic is IPublicSharedMetadata {
     /// @param tokenOfEdition Token ID for specific token
     /// @param editionSize Size of entire edition to show
     function createMetadataEdition(
-        string memory name,
-        string memory description,
-        string memory imageUrl,
-        string memory animationUrl,
+        string calldata name,
+        string calldata description,
+        string calldata imageUrl,
+        string calldata animationUrl,
         uint256 tokenOfEdition,
         uint256 editionSize
     ) external pure returns (string memory) {
@@ -51,7 +51,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
             animationUrl,
             tokenOfEdition
         );
-        bytes memory json = createMetadataJSON(
+        string memory json = createMetadataJSON(
             name,
             description,
             _tokenMediaData,
@@ -68,21 +68,21 @@ contract SharedNFTLogic is IPublicSharedMetadata {
     /// @param tokenOfEdition Token ID for specific token
     /// @param editionSize Size of entire edition to show
     function createMetadataJSON(
-        string memory name,
-        string memory description,
+        string calldata name,
+        string calldata description,
         string memory mediaData,
         uint256 tokenOfEdition,
         uint256 editionSize
-    ) public pure returns (bytes memory) {
-        bytes memory editionSizeText;
+    ) public pure returns (string memory) {
+        string memory editionSizeText;
         if (editionSize > 0) {
-            editionSizeText = abi.encodePacked(
+            editionSizeText = string.concat(
                 "/",
                 numberToString(editionSize)
             );
         }
         return
-            abi.encodePacked(
+            string.concat(
                 '{"name": "',
                 name,
                 " ",
@@ -112,52 +112,47 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         uint256 royaltyBPS,
         address royaltyRecipient
     ) public pure returns (string memory) {
-        bytes memory imageSpace = bytes("");
+        string memory imageSpace = "";
         if (bytes(imageURI).length > 0) {
-            imageSpace = abi.encodePacked('", "image": "', imageURI);
+            imageSpace = string.concat('", "image": "', imageURI);
         }
 
-        bytes memory externalURLSpace = bytes("");
+        string memory externalURLSpace = "";
         if (bytes(externalURL).length > 0) {
-            externalURLSpace = abi.encodePacked('", "external_link": "', externalURL);
+            externalURLSpace = string.concat('", "external_link": "', externalURL);
         }
 
         return
-            string(
-                encodeMetadataJSON(
-                    abi.encodePacked(
-                        '{"name": "',
-                        name,
-                        '", "description": "',
-                        description,
-                        // this is for opensea since they don't respect ERC2981 right now
-                        '", "seller_fee_basis_points": ',
-                        StringsUpgradeable.toString(royaltyBPS),
-                        ', "fee_recipient": "',
-                        StringsUpgradeable.toHexString(royaltyRecipient),
-                        imageSpace,
-                        externalURLSpace,
-                        '"}'
-                    )
+            encodeMetadataJSON(
+                string.concat(
+                    '{"name": "',
+                    name,
+                    '", "description": "',
+                    description,
+                    // this is for opensea since they don't respect ERC2981 right now
+                    '", "seller_fee_basis_points": ',
+                    StringsUpgradeable.toString(royaltyBPS),
+                    ', "fee_recipient": "',
+                    StringsUpgradeable.toHexString(royaltyRecipient),
+                    imageSpace,
+                    externalURLSpace,
+                    '"}'
                 )
             );
     }
 
     /// Encodes the argument json bytes into base64-data uri format
     /// @param json Raw json to base64 and turn into a data-uri
-    function encodeMetadataJSON(bytes memory json)
+    function encodeMetadataJSON(string memory json)
         public
         pure
         override
         returns (string memory)
     {
-        return
-            string(
-                abi.encodePacked(
-                    "data:application/json;base64,",
-                    base64Encode(json)
-                )
-            );
+        return string.concat(
+            "data:application/json;base64,",
+            base64Encode(bytes(json))
+        );
     }
 
     /// Generates edition metadata from storage information as base64-json blob
@@ -172,44 +167,29 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         bool hasImage = bytes(imageUrl).length > 0;
         bool hasAnimation = bytes(animationUrl).length > 0;
         if (hasImage && hasAnimation) {
-            return
-                string(
-                    abi.encodePacked(
-                        'image": "',
-                        imageUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        '", "animation_url": "',
-                        animationUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        '", "'
-                    )
-                );
+            return string.concat(
+                'image": "', imageUrl,
+                "?id=", numberToString(tokenOfEdition),
+                '", "animation_url": "', animationUrl,
+                "?id=", numberToString(tokenOfEdition),
+                '", "'
+            );
         }
         if (hasImage) {
-            return
-                string(
-                    abi.encodePacked(
-                        'image": "',
-                        imageUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        '", "'
-                    )
-                );
+            return string.concat(
+                'image": "', imageUrl,
+                "?id=", numberToString(tokenOfEdition),
+                '", "'
+            );
         }
         if (hasAnimation) {
-            return
-                string(
-                    abi.encodePacked(
-                        'animation_url": "',
-                        animationUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        '", "'
-                    )
-                );
+            return string.concat(
+                'animation_url": "',
+                animationUrl,
+                "?id=",
+                numberToString(tokenOfEdition),
+                '", "'
+            );
         }
 
         return "";

--- a/contracts/interfaces/IPublicSharedMetadata.sol
+++ b/contracts/interfaces/IPublicSharedMetadata.sol
@@ -11,7 +11,7 @@ interface IPublicSharedMetadata {
 
     /// Encodes the argument json bytes into base64-data uri format
     /// @param json Raw json to base64 and turn into a data-uri
-    function encodeMetadataJSON(bytes memory json)
+    function encodeMetadataJSON(string memory json)
         external
         pure
         returns (string memory);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,6 +33,7 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 100,
       },
+      viaIR: true
     },
   },
 };

--- a/test/EditionPurchaseTest.ts
+++ b/test/EditionPurchaseTest.ts
@@ -61,7 +61,12 @@ describe("Edition", () => {
     expect(await minterContract.symbol()).to.be.equal("TEST");
 
     const [_, s2] = await ethers.getSigners();
-    await expect(minterContract.purchase()).to.be.revertedWith("Not for sale");
+
+    // the revert reason is not detected properly when compiled with viaIR
+    // see https://github.com/NomicFoundation/hardhat/issues/2453
+    // await expect(minterContract.purchase()).to.be.revertedWith("Not for sale");
+    await expect(minterContract.purchase()).to.be.reverted;
+
     await expect(
       minterContract.connect(s2).setSalePrice(ethers.utils.parseEther("0.2"))
     ).to.be.revertedWith("Ownable: caller is not the owner");

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -143,7 +143,6 @@ describe("Edition", () => {
       expect(metadata.external_link).to.equal("https://example.com");
     });
 
-
     it("can mint", async () => {
       // Mint first edition
       await expect(minterContract.mintEdition(signerAddress))

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -133,6 +133,17 @@ describe("Edition", () => {
       expect(metadata.fee_recipient).to.equal((await minterContract.owner()).toLowerCase());
     });
 
+    it("can set the external URL", async () => {
+      await minterContract.setExternalUrl("https://example.com");
+      expect(await minterContract.externalUrl()).to.equal("https://example.com");
+
+      // when it has been set, we see it reflected in contractURI()
+      const contractURI = await minterContract.contractURI();
+      const metadata = parseMetadataURI(contractURI);
+      expect(metadata.external_link).to.equal("https://example.com");
+    });
+
+
     it("can mint", async () => {
       // Mint first edition
       await expect(minterContract.mintEdition(signerAddress))

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -240,6 +240,7 @@ describe("Edition", () => {
         await signer1.getAddress()
       );
     });
+
     it("allows user burn", async () => {
       await minterContract.mintEdition(await signer1.getAddress());
       expect(await minterContract.ownerOf(1)).to.equal(
@@ -299,6 +300,7 @@ describe("Edition", () => {
       // ERC721 interface
       expect(await minterContract.supportsInterface("0x80ac58cd")).to.be.true;
     });
+
     describe("royalty 2981", () => {
       it("follows royalty payout for owner", async () => {
         await minterContract.mintEdition(signerAddress);

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -158,17 +158,30 @@ describe("Edition", () => {
       expect(await minterContract.externalUrl()).to.equal("https://example.com");
 
       // then we see it reflected in contractURI()
-      const contractURI = await minterContract.contractURI();
-      const metadata = parseMetadataURI(contractURI);
+      let contractURI = await minterContract.contractURI();
+      let metadata = parseMetadataURI(contractURI);
       expect(metadata.external_link).to.equal("https://example.com");
 
       // when we mint a token
       await minterContract.mintEdition(signerAddress);
 
       // then we see the external url reflected in tokenURI()
-      const tokenURI = await minterContract.tokenURI(1);
-      const tokenMetadata = parseMetadataURI(tokenURI);
+      let tokenURI = await minterContract.tokenURI(1);
+      let tokenMetadata = parseMetadataURI(tokenURI);
       expect(tokenMetadata.external_url).to.equal("https://example.com");
+
+      // when we set the external url to an empty string
+      await minterContract.setExternalUrl("");
+
+      // then we no longer see it in contractURI()
+      contractURI = await minterContract.contractURI();
+      metadata = parseMetadataURI(contractURI);
+      expect(metadata.external_link).to.be.undefined;
+
+      // and we no longer see it in tokenURI()
+      tokenURI = await minterContract.tokenURI(1);
+      tokenMetadata = parseMetadataURI(tokenURI);
+      expect(tokenMetadata.external_url).to.be.undefined;
     });
 
     it("can mint", async () => {

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -153,13 +153,22 @@ describe("Edition", () => {
     });
 
     it("can set the external URL", async () => {
+      // when the external url is set
       await minterContract.setExternalUrl("https://example.com");
       expect(await minterContract.externalUrl()).to.equal("https://example.com");
 
-      // when it has been set, we see it reflected in contractURI()
+      // then we see it reflected in contractURI()
       const contractURI = await minterContract.contractURI();
       const metadata = parseMetadataURI(contractURI);
       expect(metadata.external_link).to.equal("https://example.com");
+
+      // when we mint a token
+      await minterContract.mintEdition(signerAddress);
+
+      // then we see the external url reflected in tokenURI()
+      const tokenURI = await minterContract.tokenURI(1);
+      const tokenMetadata = parseMetadataURI(tokenURI);
+      expect(tokenMetadata.external_url).to.equal("https://example.com");
     });
 
     it("can mint", async () => {

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -99,8 +99,27 @@ describe("Edition", () => {
       "https://ipfs.io/ipfsbafybeify52a63pgcshhbtkff4nxxxp2zp5yjn2xw43jcy4knwful7ymmgy"
     );
     expect(await minterContract.editionSize()).to.equal(10);
-    // TODO(iain): check bps
     expect(await minterContract.owner()).to.equal(signerAddress);
+
+    let { receiver, royaltyAmount } = await minterContract.royaltyInfo(1, 20000);
+    expect(receiver).to.equal(signerAddress);
+    expect(royaltyAmount).to.equal(20);
+  });
+
+  it("makes a new edition with both an imageUrl and an animationUrl", async () => {
+    const args = [
+      "Testing Token",
+      "TEST",
+      "This is a testing token for all",
+      "https://example.com/animationUrl",
+      "https://example.com/imageUrl",
+      10,
+      10,
+    ];
+
+    const edition = await createEdition(dynamicSketch, args);
+    expect(await edition.animationUrl()).to.equal("https://example.com/animationUrl");
+    expect(await edition.imageUrl()).to.equal("https://example.com/imageUrl");
   });
 
   describe("with an edition", () => {


### PR DESCRIPTION
A little odd but according to https://docs.opensea.io/docs/metadata-standards:
- external_link in contractURI()
- external_url in tokenURI()

Plus
- some memory -> calldata optimizations (a little cheaper in gas)
- compile with viaIR: true 
- simplify tokenMetaData logic
- replace bytes with string
- replace abi.encodePacked with string.concat