### PR TITLE
Add support for a grace period before freezing metadata

### DIFF
--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -131,14 +131,17 @@ contract Edition is
         allowedMinters[minter] = allowed;
     }
 
-    /// @dev Allows for updates of edition urls by the owner of the edition.
-    function updateEditionURLs(
-        string memory _imageUrl,
-        string memory _animationUrl
-    ) public onlyOwner {
-        imageUrl = _imageUrl;
+    /// @dev Allows the owner to update the animation url for the edition
+    function setAnimationUrl(string calldata _animationUrl) public override onlyOwner {
         animationUrl = _animationUrl;
     }
+
+
+    /// @dev Allows the owner to update the image url for the edition
+    function setImageUrl(string calldata _imageUrl) public override onlyOwner {
+        imageUrl = _imageUrl;
+    }
+
 
     /// @notice Updates the external_url field in the metadata
     function setExternalUrl(string calldata _externalUrl) public onlyOwner {

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -146,22 +146,37 @@ contract Edition is
     }
 
     function setDescription(string calldata _description) public override onlyOwner notFrozen {
+        // log the current description
+        emit DescriptionUpdated(description);
+
+        // switch to the new one
         description = _description;
     }
 
     /// @dev Allows the owner to update the animation url for the edition
     function setAnimationUrl(string calldata _animationUrl) public override onlyOwner notFrozen {
+        // log the current animation url
+        emit AnimationUrlUpdated(animationUrl);
+
+        // switch to the new one
         animationUrl = _animationUrl;
     }
 
     /// @dev Allows the owner to update the image url for the edition
     function setImageUrl(string calldata _imageUrl) public override onlyOwner notFrozen {
+        // log the current image url
+        emit ImageUrlUpdated(imageUrl);
+
+        // switch to the new one
         imageUrl = _imageUrl;
     }
 
     /// @notice Updates the external_url field in the metadata
     /// @notice can be updated by the owner regardless of the grace period
     function setExternalUrl(string calldata _externalUrl) public onlyOwner {
+        // log the current external url
+        emit ExternalUrlUpdated(externalUrl);
+
         externalUrl = _externalUrl;
     }
 

--- a/contracts/EditionCreator.sol
+++ b/contracts/EditionCreator.sol
@@ -37,11 +37,11 @@ contract EditionCreator is IEditionCreator {
     /// @param _editionSize Total size of the edition (number of possible editions)
     /// @param _royaltyBPS BPS amount of royalty
     function createEdition(
-        string memory _name,
-        string memory _symbol,
-        string memory _description,
-        string memory _animationUrl,
-        string memory _imageUrl,
+        string calldata _name,
+        string calldata _symbol,
+        string calldata _description,
+        string calldata _animationUrl,
+        string calldata _imageUrl,
         uint256 _editionSize,
         uint256 _royaltyBPS
     ) external override returns (IEdition newContract) {

--- a/contracts/EditionCreator.sol
+++ b/contracts/EditionCreator.sol
@@ -28,7 +28,7 @@ contract EditionCreator is IEditionCreator {
     }
 
     /// Creates a new edition contract as a factory with a deterministic address
-    /// Important: None of these fields (except the Url fields with the same hash) can be changed after calling
+    /// Important: most of these fields can not be changed after calling
     /// @param _name Name of the edition contract
     /// @param _symbol Symbol of the edition contract
     /// @param _description Metadata: Description of the edition entry
@@ -36,6 +36,8 @@ contract EditionCreator is IEditionCreator {
     /// @param _imageUrl Metadata: Image url (semi-required) of the edition entry
     /// @param _editionSize Total size of the edition (number of possible editions)
     /// @param _royaltyBPS BPS amount of royalty
+    /// @param _metadataGracePeriodSeconds Number of seconds after minting that metadata can be updated by the owner, 0 to have no grace period
+    /// @return newContract The address of the created edition
     function createEdition(
         string calldata _name,
         string calldata _symbol,
@@ -43,7 +45,8 @@ contract EditionCreator is IEditionCreator {
         string calldata _animationUrl,
         string calldata _imageUrl,
         uint256 _editionSize,
-        uint256 _royaltyBPS
+        uint256 _royaltyBPS,
+        uint256 _metadataGracePeriodSeconds
     ) external override returns (IEdition newContract) {
         bytes32 salt = keccak256(abi.encodePacked(msg.sender, _name, _symbol, _animationUrl, _imageUrl));
         newContract = IEdition(ClonesUpgradeable.cloneDeterministic(
@@ -59,7 +62,8 @@ contract EditionCreator is IEditionCreator {
             _animationUrl,
             _imageUrl,
             _editionSize,
-            _royaltyBPS
+            _royaltyBPS,
+            _metadataGracePeriodSeconds
         );
 
         emit CreatedEdition(uint256(salt), msg.sender, _editionSize, address(newContract));

--- a/contracts/interfaces/IEdition.sol
+++ b/contracts/interfaces/IEdition.sol
@@ -23,7 +23,8 @@ interface IEdition {
         string memory _animationUrl,
         string memory _imageUrl,
         uint256 _editionSize,
-        uint256 _royaltyBPS
+        uint256 _royaltyBPS,
+        uint256 metadataGracePeriod
     ) external;
 
     function maxSupply() external view returns (uint256);
@@ -41,6 +42,8 @@ interface IEdition {
     function setAnimationUrl(string calldata animationUrl) external;
 
     function setApprovedMinter(address minter, bool allowed) external;
+
+    function setDescription(string calldata description) external;
 
     function setImageUrl(string calldata imageUrl) external;
 

--- a/contracts/interfaces/IEdition.sol
+++ b/contracts/interfaces/IEdition.sol
@@ -38,16 +38,16 @@ interface IEdition {
 
     function salePrice() external view returns (uint256);
 
+    function setAnimationUrl(string calldata animationUrl) external;
+
     function setApprovedMinter(address minter, bool allowed) external;
+
+    function setImageUrl(string calldata imageUrl) external;
 
     function setSalePrice(uint256 _salePrice) external;
 
     function totalSupply() external view returns (uint256);
 
-    function updateEditionURLs(
-        string memory _imageUrl,
-        string memory _animationUrl
-    ) external;
 
     function withdraw() external;
 }

--- a/contracts/interfaces/IEdition.sol
+++ b/contracts/interfaces/IEdition.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.6;
 interface IEdition {
     event EditionSold(uint256 price, address owner);
     event PriceChanged(uint256 amount);
+    event DescriptionUpdated(string oldDescription);
+    event AnimationUrlUpdated(string oldAnimationUrl);
+    event ImageUrlUpdated(string oldImageUrl);
+    event ExternalUrlUpdated(string oldExternalUrl);
 
     function animationUrl() external view returns (string memory);
 

--- a/contracts/interfaces/IEditionCreator.sol
+++ b/contracts/interfaces/IEditionCreator.sol
@@ -19,7 +19,8 @@ interface IEditionCreator {
         string memory _animationUrl,
         string memory _imageUrl,
         uint256 _editionSize,
-        uint256 _royaltyBPS
+        uint256 _royaltyBPS,
+        uint256 _metadataGracePeriodSeconds
     ) external returns (IEdition);
 
     /// Get edition given the created ID

--- a/test/EditionPurchaseTest.ts
+++ b/test/EditionPurchaseTest.ts
@@ -56,6 +56,7 @@ describe("Edition", () => {
       "",
       10,
       10,
+      24 * 3600
     ]);
     expect(await minterContract.name()).to.be.equal("Testing Token");
     expect(await minterContract.symbol()).to.be.equal("TEST");

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -152,6 +152,20 @@ describe("Edition", () => {
       expect(metadata.fee_recipient).to.equal((await minterContract.owner()).toLowerCase());
     });
 
+    it("lets the owner call setImageUrl()", async () => {
+      await minterContract.setImageUrl("https://example.com/imageUrl");
+      expect(await minterContract.imageUrl()).to.equal("https://example.com/imageUrl");
+    });
+
+    it("does not let a non-owner call setImageUrl()", async () => {
+      await expect(minterContract.connect(signer1).setImageUrl("https://example.com/imageUrl")).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("lets the owner call setAnimationUrl()", async () => {
+      await minterContract.setAnimationUrl("https://example.com/animationUrl");
+      expect(await minterContract.animationUrl()).to.equal("https://example.com/animationUrl");
+    });
+
     describe("when we set the external URL", () => {
       beforeEach(async () => {
         await minterContract.setExternalUrl("https://example.com");

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -50,7 +50,7 @@ describe("Edition", () => {
     DEFAULT_METADATA_GRACE_PERIOD,
   ];
 
-  let createEdition = async function(factory: EditionCreator, args: any): Promise<Edition> {
+  let createEdition = async function (factory: EditionCreator, args: any): Promise<Edition> {
     // first simulate the call to get the output
     // @ts-ignore
     const editionAddress = await factory.callStatic.createEdition(...args);
@@ -140,30 +140,42 @@ describe("Edition", () => {
 
     describe("during the grace period", () => {
       it("lets the owner call setImageUrl()", async () => {
-        await minterContract.setImageUrl("https://example.com/imageUrl");
+        await expect(minterContract.setImageUrl("https://example.com/imageUrl"))
+          .to.emit(minterContract, "ImageUrlUpdated")
+          .withArgs(DEFAULT_IMAGE_URL);
+
         expect(await minterContract.imageUrl()).to.equal("https://example.com/imageUrl");
       });
 
       it("lets the owner call setAnimationUrl()", async () => {
-        await minterContract.setAnimationUrl("https://example.com/animationUrl");
+        await expect(minterContract.setAnimationUrl("https://example.com/animationUrl"))
+          .to.emit(minterContract, "AnimationUrlUpdated")
+          .withArgs(DEFAULT_ANIMATION_URL);
+
         expect(await minterContract.animationUrl()).to.equal("https://example.com/animationUrl");
       });
 
       it("lets the owner call setDescription()", async () => {
-        await minterContract.setDescription("New description");
+        await expect(minterContract.setDescription("New description"))
+          .to.emit(minterContract, "DescriptionUpdated")
+          .withArgs(DEFAULT_DESCRIPTION);
+
         expect(await minterContract.description()).to.equal("New description");
       });
 
       it("does not let a non-owner call setAnimationUrl()", async () => {
-        await expect(minterContract.connect(signer1).setAnimationUrl("")).to.be.revertedWith("Ownable: caller is not the owner");
+        await expect(minterContract.connect(signer1).setAnimationUrl(""))
+          .to.be.revertedWith("Ownable: caller is not the owner");
       });
 
       it("does not let a non-owner call setImageUrl()", async () => {
-        await expect(minterContract.connect(signer1).setImageUrl("")).to.be.revertedWith("Ownable: caller is not the owner");
+        await expect(minterContract.connect(signer1).setImageUrl(""))
+          .to.be.revertedWith("Ownable: caller is not the owner");
       });
 
       it("does not let a non-owner call setDescription()", async () => {
-        await expect(minterContract.connect(signer1).setDescription("")).to.be.revertedWith("Ownable: caller is not the owner");
+        await expect(minterContract.connect(signer1).setDescription(""))
+          .to.be.revertedWith("Ownable: caller is not the owner");
       });
     });
 
@@ -193,7 +205,8 @@ describe("Edition", () => {
 
     describe("when we set the external URL", () => {
       beforeEach(async () => {
-        await minterContract.setExternalUrl("https://example.com");
+        await expect(minterContract.setExternalUrl("https://example.com"))
+          .to.emit(minterContract, "ExternalUrlUpdated").withArgs("");
         expect(await minterContract.externalUrl()).to.equal("https://example.com");
       });
 


### PR DESCRIPTION
Before:
- description not editable
- imageUrl and animationUrl was always editable

After:
- description, imageUrl and animationUrl can be edited until frozen
- there is an `isMetadataFrozen()` public getter
