### PR TITLE
Add support for custom string properties

### DIFF
--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -194,7 +194,9 @@ contract Edition is
                 revert("bad attribute");
             }
 
-            stringProperties[names[i]] = values[i];
+            emit PropertyUpdated(name, stringProperties[name], value);
+
+            stringProperties[name] = value;
 
             unchecked {
                 ++i;

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -136,7 +136,7 @@ contract Edition is
         notFrozen
     {
         // log the current description
-        emit DescriptionUpdated(description);
+        emit DescriptionUpdated(description, _description);
 
         // switch to the new one
         description = _description;
@@ -150,7 +150,7 @@ contract Edition is
         notFrozen
     {
         // log the current animation url
-        emit AnimationUrlUpdated(animationUrl);
+        emit AnimationUrlUpdated(animationUrl, _animationUrl);
 
         // switch to the new one
         animationUrl = _animationUrl;
@@ -164,7 +164,7 @@ contract Edition is
         notFrozen
     {
         // log the current image url
-        emit ImageUrlUpdated(imageUrl);
+        emit ImageUrlUpdated(imageUrl, _imageUrl);
 
         // switch to the new one
         imageUrl = _imageUrl;
@@ -174,7 +174,7 @@ contract Edition is
     /// @notice can be updated by the owner regardless of the grace period
     function setExternalUrl(string calldata _externalUrl) public onlyOwner {
         // log the current external url
-        emit ExternalUrlUpdated(externalUrl);
+        emit ExternalUrlUpdated(externalUrl, _externalUrl);
 
         externalUrl = _externalUrl;
     }

--- a/contracts/EditionMetadataState.sol
+++ b/contracts/EditionMetadataState.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.6;
+
+contract EditionMetadataState {
+    string public description;
+
+    // Media Urls
+    // animation_url field in the metadata
+    string public animationUrl;
+
+    // Image in the metadata
+    string public imageUrl;
+
+    // URL that will appear below the asset's image on OpenSea
+    string public externalUrl;
+
+    string[] internal namesOfStringProperties;
+
+    mapping(string => string) internal stringProperties;
+}

--- a/contracts/interfaces/IEdition.sol
+++ b/contracts/interfaces/IEdition.sol
@@ -13,6 +13,7 @@ interface IEdition {
     event AnimationUrlUpdated(string oldAnimationUrl);
     event ImageUrlUpdated(string oldImageUrl);
     event ExternalUrlUpdated(string oldExternalUrl);
+    event PropertyUpdated(string name, string oldValue, string newValue);
 
     function burn(uint256 tokenId) external;
 

--- a/contracts/interfaces/IEdition.sol
+++ b/contracts/interfaces/IEdition.sol
@@ -9,10 +9,10 @@ struct StringAttribute {
 interface IEdition {
     event EditionSold(uint256 price, address owner);
     event PriceChanged(uint256 amount);
-    event DescriptionUpdated(string oldDescription);
-    event AnimationUrlUpdated(string oldAnimationUrl);
-    event ImageUrlUpdated(string oldImageUrl);
-    event ExternalUrlUpdated(string oldExternalUrl);
+    event DescriptionUpdated(string oldDescription, string newDescription);
+    event AnimationUrlUpdated(string oldAnimationUrl, string newAnimationUrl);
+    event ImageUrlUpdated(string oldImageUrl, string newImageUrl);
+    event ExternalUrlUpdated(string oldExternalUrl, string newExternalUrl);
     event PropertyUpdated(string name, string oldValue, string newValue);
 
     function burn(uint256 tokenId) external;

--- a/contracts/interfaces/IEdition.sol
+++ b/contracts/interfaces/IEdition.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.6;
 
+struct StringAttribute {
+    string name;
+    string value;
+}
+
 interface IEdition {
     event EditionSold(uint256 price, address owner);
     event PriceChanged(uint256 amount);
@@ -9,15 +14,9 @@ interface IEdition {
     event ImageUrlUpdated(string oldImageUrl);
     event ExternalUrlUpdated(string oldExternalUrl);
 
-    function animationUrl() external view returns (string memory);
-
     function burn(uint256 tokenId) external;
 
-    function description() external view returns (string memory);
-
     function editionSize() external view returns (uint256);
-
-    function imageUrl() external view returns (string memory);
 
     function initialize(
         address _owner,
@@ -54,7 +53,6 @@ interface IEdition {
     function setSalePrice(uint256 _salePrice) external;
 
     function totalSupply() external view returns (uint256);
-
 
     function withdraw() external;
 }

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -230,27 +230,30 @@ describe("Edition", () => {
 
     describe("during the grace period", () => {
       it("lets the owner call setImageUrl()", async () => {
-        await expect(minterContract.setImageUrl("https://example.com/imageUrl"))
+        const newImageUrl = "https://example.com/newImageUrl";
+        await expect(minterContract.setImageUrl(newImageUrl))
           .to.emit(minterContract, "ImageUrlUpdated")
-          .withArgs(DEFAULT_IMAGE_URL);
+          .withArgs(DEFAULT_IMAGE_URL, newImageUrl);
 
-        expect(await minterContract.imageUrl()).to.equal("https://example.com/imageUrl");
+        expect(await minterContract.imageUrl()).to.equal(newImageUrl);
       });
 
       it("lets the owner call setAnimationUrl()", async () => {
-        await expect(minterContract.setAnimationUrl("https://example.com/animationUrl"))
+        const newAnimationUrl = "https://example.com/newAnimationUrl";
+        await expect(minterContract.setAnimationUrl(newAnimationUrl))
           .to.emit(minterContract, "AnimationUrlUpdated")
-          .withArgs(DEFAULT_ANIMATION_URL);
+          .withArgs(DEFAULT_ANIMATION_URL, newAnimationUrl);
 
-        expect(await minterContract.animationUrl()).to.equal("https://example.com/animationUrl");
+        expect(await minterContract.animationUrl()).to.equal(newAnimationUrl);
       });
 
       it("lets the owner call setDescription()", async () => {
-        await expect(minterContract.setDescription("New description"))
+        const newDescription = "new description";
+        await expect(minterContract.setDescription(newDescription))
           .to.emit(minterContract, "DescriptionUpdated")
-          .withArgs(DEFAULT_DESCRIPTION);
+          .withArgs(DEFAULT_DESCRIPTION, newDescription);
 
-        expect(await minterContract.description()).to.equal("New description");
+        expect(await minterContract.description()).to.equal(newDescription);
       });
 
       it("does not let a non-owner call setAnimationUrl()", async () => {
@@ -294,23 +297,25 @@ describe("Edition", () => {
     });
 
     describe("when we set the external URL", () => {
+      const externalUrl = "https://example.com/externalUrl";
+
       beforeEach(async () => {
-        await expect(minterContract.setExternalUrl("https://example.com"))
-          .to.emit(minterContract, "ExternalUrlUpdated").withArgs("");
-        expect(await minterContract.externalUrl()).to.equal("https://example.com");
+        await expect(minterContract.setExternalUrl(externalUrl))
+          .to.emit(minterContract, "ExternalUrlUpdated").withArgs("", externalUrl);
+        expect(await minterContract.externalUrl()).to.equal(externalUrl);
       });
 
       it("contractURI() reflects it as external_link", async () => {
         const contractURI = await minterContract.contractURI();
         const metadata = parseMetadataURI(contractURI);
-        expect(metadata.external_link).to.equal("https://example.com");
+        expect(metadata.external_link).to.equal(externalUrl);
       });
 
       it("tokenURI() reflects it as external_url", async () => {
         await minterContract.mintEdition(signerAddress);
         const tokenURI = await minterContract.tokenURI(1);
         const metadata = parseMetadataURI(tokenURI);
-        expect(metadata.external_url).to.equal("https://example.com");
+        expect(metadata.external_url).to.equal(externalUrl);
       });
 
       it("it can be unset", async () => {


### PR DESCRIPTION
High level:

- Edition.setStringProperties() can be called by the owner to create/update/delete custom properties
- custom properties are returned as part of tokenURI() in Enjin Metadata style: `"properties": {"simple_property": "simple_value"}`

Nitty gritty: shuffling values back and forth from Edition's storage to the renderer starting becoming challenging, so I'm rearranging things a bit

- breaking out EditionMetadataState
- NFTMetadataRenderer renamed to EditionMetadataRenderer
- EditionMetadataRenderer inherits from EditionMetadataState so that it can access the state directly
- Edition inherits from EditionMetadataRenderer, it provides the setters and the access control
- removing the default baked-in `number` and `name` properties