### PR TITLE
Fix totalSupply logic

### DIFF
--- a/contracts/interfaces/IEdition.sol
+++ b/contracts/interfaces/IEdition.sol
@@ -36,6 +36,8 @@ interface IEdition {
         external
         returns (uint256);
 
+    function numberCanMint() external view returns (uint256);
+
     function purchase() external payable returns (uint256);
 
     function salePrice() external view returns (uint256);

--- a/test/EditionMetadataTest.sol
+++ b/test/EditionMetadataTest.sol
@@ -18,7 +18,7 @@ contract EditionMetadataTest is Test {
     Edition editionToEscape;
     Edition editionIntense;
 
-    uint256 constant tokenId = 1;
+    uint256 tokenId;
 
     function createEdition(string memory name, string memory description)
         internal
@@ -63,7 +63,7 @@ contract EditionMetadataTest is Test {
             intenseDescription
         );
 
-        edition.mintEdition(address(0xdEaD));
+        tokenId = edition.mintEdition(address(0xdEaD));
         editionToEscape.mintEdition(address(0xdEaD));
     }
 
@@ -120,6 +120,19 @@ contract EditionMetadataTest is Test {
         // console2.log("description:", description);
 
         assertEq(description, LibString.repeat("\\", INTENSE_LENGTH));
+    }
+
+    function testBurnDecreasesTotalSupply() public {
+        address bob = makeAddr("bob");
+        edition.setApprovedMinter(bob, true);
+        vm.startPrank(bob);
+        uint256 bobsTokenId = edition.mintEdition(bob);
+
+        uint256 totalSupplyBefore = edition.totalSupply();
+
+        edition.burn(bobsTokenId);
+        assertEq(edition.totalSupply(), totalSupplyBefore - 1);
+        vm.stopPrank();
     }
 
     function testCreateEditionWithEmptyDescription() public {

--- a/test/EditionTest.ts
+++ b/test/EditionTest.ts
@@ -421,6 +421,12 @@ describe("Edition", () => {
       await expect(minterContract.connect(signer2).burn(1)).to.be.revertedWith("Not approved");
     });
 
+    it("does not allow to burn the same token twice", async () => {
+      await minterContract.mintEdition(signerAddress);
+      await minterContract.burn(1);
+      await expect(minterContract.burn(1)).to.be.revertedWith("ERC721: invalid token ID");
+    });
+
     it("does not allow re-initialization", async () => {
       await expect(
         minterContract.initialize(


### PR DESCRIPTION
- totalSupply was actually just numberMinted, so it would not decrease after token burns
- keep track of numberMinted and numberBurned separately
- bring back numberCanMint() (now with check for isMintingEnded())
- update totalSupply() to reflect numberMinted and numberBurned
- add more burn tests