### PR TITLE
Fix underflow bug

### DIFF
--- a/contracts/solmate-initializable/tokens/SS2ERC721.sol
+++ b/contracts/solmate-initializable/tokens/SS2ERC721.sol
@@ -56,6 +56,10 @@ abstract contract SS2ERC721 is ERC721 {
     }
 
     function _ownersPrimaryLength() internal view returns (uint256) {
+        if (_ownersPrimaryPointer == address(0)) {
+            return 0;
+        }
+
         return (_ownersPrimaryPointer.code.length - 1) / 20;
     }
 

--- a/test/SS2ERC721.t.sol
+++ b/test/SS2ERC721.t.sol
@@ -118,6 +118,16 @@ contract ERC721Test is Test {
         assertEq(token.ownerOf(1), address(0xBEEF));
     }
 
+    function testBalanceOfBeforeMint() public {
+        assertEq(token.balanceOf(address(0xBEEF)), 0);
+    }
+
+    function testOwnerOfBeforeMint(uint256 n) public {
+        vm.assume(n > 0);
+        vm.expectRevert("NOT_MINTED");
+        token.ownerOf(n);
+    }
+
     function testMint2() public {
         address to1 = 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa;
         address to2 = 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB;


### PR DESCRIPTION
Querying ownerOf(tokenId) or balanceOf(owner) before mint resulted in an underflow