### PR TITLE
 Add opt-in support for OpenSea operator filtering compliance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,7 @@
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable
 	branch = v4.8.0
+[submodule "lib/operator-filter-registry"]
+	path = lib/operator-filter-registry
+	url = https://github.com/ProjectOpenSea/operator-filter-registry
+	branch = v1.3.1

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -20,6 +20,7 @@ import {OwnedInitializable} from "./solmate-initializable/auth/OwnedInitializabl
 
 import {EditionMetadataRenderer} from "./EditionMetadataRenderer.sol";
 import {IEdition} from "./interfaces/IEdition.sol";
+import {OptionalOperatorFilterer} from "./utils/OptionalOperatorFilterer.sol";
 
 import "./interfaces/Errors.sol";
 
@@ -33,7 +34,8 @@ contract Edition is
     ERC721I,
     IEdition,
     IERC2981Upgradeable,
-    OwnedInitializable
+    OwnedInitializable,
+    OptionalOperatorFilterer
 {
     struct EditionState {
         // how many tokens have been minted (can not be more than editionSize)
@@ -108,6 +110,27 @@ contract Edition is
     }
 
     /*//////////////////////////////////////////////////////////////
+                      OPERATOR FILTERER OVERRIDES
+    //////////////////////////////////////////////////////////////*/
+
+    function transferFrom(address from, address to, uint256 tokenId) public override onlyAllowedOperator(from) {
+        super.transferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) public override onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data)
+        public
+        override
+        onlyAllowedOperator(from)
+    {
+        super.safeTransferFrom(from, to, tokenId, data);
+    }
+
+
+    /*//////////////////////////////////////////////////////////////
                   CREATOR / COLLECTION OWNER FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
@@ -175,6 +198,10 @@ contract Edition is
                 ++i;
             }
         }
+    }
+
+    function setOperatorFilter(address operatorFilter) public onlyOwner {
+        _setOperatorFilter(operatorFilter);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/Edition.sol
+++ b/contracts/Edition.sol
@@ -90,18 +90,18 @@ contract Edition is
         animationUrl = _animationUrl;
         imageUrl = _imageUrl;
 
-        uint64 endOfMintPeriod;
+        uint64 _endOfMintPeriod;
         if (_mintPeriodSeconds > 0) {
             // overflows are not expected to happen for timestamps, and have no security implications
             unchecked {
                 uint256 endOfMintPeriodUint256 = block.timestamp + _mintPeriodSeconds;
-                endOfMintPeriod = requireUint64(endOfMintPeriodUint256);
+                _endOfMintPeriod = requireUint64(endOfMintPeriodUint256);
             }
         }
 
         state = EditionState({
             editionSize: requireUint64(_editionSize),
-            endOfMintPeriod: endOfMintPeriod,
+            endOfMintPeriod: _endOfMintPeriod,
             royaltyBPS: requireUint16(_royaltyBPS),
             salePriceTwei: 0,
             numberMinted: 0,

--- a/contracts/interfaces/Errors.sol
+++ b/contracts/interfaces/Errors.sol
@@ -6,6 +6,7 @@ error IntegerOverflow(uint256 value);
 error InvalidArgument();
 error LengthMismatch();
 error NotForSale();
+error OperatorNotAllowed(address operator);
 error PriceTooLow();
 error SoldOut();
 error TimeLimitReached();

--- a/contracts/utils/OptionalOperatorFilterer.sol
+++ b/contracts/utils/OptionalOperatorFilterer.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.6;
+
+import { IOperatorFilterRegistry } from "operator-filter-registry/IOperatorFilterRegistry.sol";
+
+import { OperatorNotAllowed } from "../interfaces/Errors.sol";
+
+/// Less aggro than DefaultOperatorFilterer, it does not automatically register and subscribe to the default filter
+/// Instead, this is off by default, opt-in, and relies only on view functions (no register call)
+abstract contract OptionalOperatorFilterer {
+    address public constant CANONICAL_OPENSEA_SUBSCRIPTION = address(0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6);
+    address public constant CANONICAL_OPENSEA_REGISTRY = address(0x000000000000AAeB6D7670E522A718067333cd4E);
+
+    address public activeOperatorFilter = address(0);
+
+    event OperatorFilterChanged(address indexed operatorFilter);
+
+    /// Set to CANONICAL_OPENSEA_SUBSCRIPTION to use the default OpenSea operator filter
+    /// Set to address(0) to disable operator filtering
+    function _setOperatorFilter(address operatorFilter) internal {
+        activeOperatorFilter = operatorFilter;
+        emit OperatorFilterChanged(operatorFilter);
+    }
+
+    /// @dev modified from operator-filter-registry/OperatorFilterer.sol
+    modifier onlyAllowedOperator(address from) virtual {
+        // Allow spending tokens from addresses with balance
+        // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
+        // from an EOA.
+        if (from != msg.sender) {
+            _checkFilterOperator(msg.sender);
+        }
+        _;
+    }
+
+    /// @dev modified from operator-filter-registry/OperatorFilterer.sol
+    function _checkFilterOperator(address operator) internal view {
+        if (activeOperatorFilter == address(0)) {
+            return;
+        }
+
+        // Check registry code length to facilitate testing in environments without a deployed registry.
+        if (CANONICAL_OPENSEA_REGISTRY.code.length == 0) {
+            return;
+        }
+
+        if (!IOperatorFilterRegistry(CANONICAL_OPENSEA_REGISTRY).isOperatorAllowed(activeOperatorFilter, operator)) {
+            revert OperatorNotAllowed(operator);
+        }
+    }
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,3 +2,4 @@ ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 solmate/=lib/solmate/src/
 @openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
+operator-filter-registry/=lib/operator-filter-registry/src/

--- a/test/Edition/EditionFunctionalTests.t.sol
+++ b/test/Edition/EditionFunctionalTests.t.sol
@@ -374,6 +374,12 @@ contract EditionFunctionalTests is EditionFixture {
         edition.transferOwnership(bob);
     }
 
+    function testOnlyOwnerCanSetOperatorFilter() public {
+        vm.expectRevert("UNAUTHORIZED");
+        vm.prank(bob);
+        edition.setOperatorFilter(bob);
+    }
+
 
     /*//////////////////////////////////////////////////////////////
                             SALE PRICE TESTS

--- a/test/Edition/EditionOperatorFiltering.t.sol
+++ b/test/Edition/EditionOperatorFiltering.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {console2} from "forge-std/console2.sol";
+import {IERC721} from "forge-std/interfaces/IERC721.sol";
+
+import {EditionFixture} from "./fixtures/EditionFixture.sol";
+
+interface IOperatorFilterRegistry {
+    function filteredOperators(address addr) external returns (address[] memory);
+}
+
+contract MockRegistry {
+    address[] public filteredOperators;
+
+    function setFilteredOperators(address[] memory _filteredOperators) public {
+        filteredOperators = _filteredOperators;
+    }
+
+    function isOperatorAllowed(address /* registrant */, address operator) public view returns (bool) {
+        for (uint256 i = 0; i < filteredOperators.length; i++) {
+            if (filteredOperators[i] == operator) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+/// @dev modified from operator-filter-registry/test/Validation.t.sol
+contract EditionOperatorFiltering is EditionFixture {
+    address constant CANONICAL_OPERATOR_FILTER_REGISTRY = 0x000000000000AAeB6D7670E522A718067333cd4E;
+    address constant CANONICAL_OPENSEA_REGISTRANT = 0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6;
+
+    // Contract to test against
+    address contractAddress;
+
+    // Token ID to test against
+    uint256 tokenId;
+
+    // Owner of the NFT
+    address owner;
+
+    address[] filteredOperators;
+
+    function setUp() public {
+        __EditionFixture_setUp();
+
+        // try to load contract address from .env
+        try vm.envAddress("CONTRACT_ADDRESS") returns (address _contractAddress) {
+            contractAddress = _contractAddress;
+        } catch (bytes memory) {
+            // fallback to deploying new contract
+            contractAddress = address(edition);
+            vm.prank(editionOwner);
+            edition.setOperatorFilter(CANONICAL_OPENSEA_REGISTRANT);
+        }
+
+        // try to load token ID from .env
+        try vm.envUint("TOKEN_ID") returns (uint256 _tokenId) {
+            tokenId = _tokenId;
+        } catch (bytes memory) {
+            // fallback to minting
+            tokenId = edition.mint(address(this));
+        }
+
+        // try to load owner from .env
+        try vm.envAddress("OWNER") returns (address _owner) {
+            owner = _owner;
+        } catch (bytes memory) {
+            // fallback to this
+            owner = address(this);
+        }
+
+        initFilteredOperators();
+    }
+
+    function initFilteredOperators() internal {
+        try vm.envString("NETWORK") returns (string memory envNetwork) {
+            vm.createSelectFork(getChain(envNetwork).rpcUrl);
+
+            filteredOperators =
+                IOperatorFilterRegistry(CANONICAL_OPERATOR_FILTER_REGISTRY).filteredOperators(CANONICAL_OPENSEA_REGISTRANT);
+        } catch {
+            // fallback to static list
+            console2.log("No network specified, using static list (Dec 2022 snapshot)");
+
+            filteredOperators =
+                abi.decode(
+                    hex"0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000111abe46ff893f3b2fdf1f759a8a8000000000000000000000000fed24ec7e22f573c2e08aef55aa6797ca2b3a051000000000000000000000000f42aa99f011a1fa7cda90e5e98b277e306bca83e000000000000000000000000b16c1342e617a5b6e4b631eb114483fdb289c0a4000000000000000000000000d42638863462d2f21bb7d4275d7637ee5d5541eb00000000000000000000000008ce97807a81896e85841d74fb7e7b065ab3ef0500000000000000000000000092de3a1511ef22abcf3526c302159882a4755b22000000000000000000000000cd80c916b1194beb48abf007d0b79a7238436d56",
+                    (address[])
+                );
+
+            MockRegistry mockRegistry = new MockRegistry();
+            vm.etch(CANONICAL_OPERATOR_FILTER_REGISTRY, address(mockRegistry).code);
+            MockRegistry(CANONICAL_OPERATOR_FILTER_REGISTRY).setFilteredOperators(filteredOperators);
+        }
+    }
+
+
+    function testOperatorFiltering() public {
+        IERC721 nftContract = IERC721(contractAddress);
+
+        // Try to get the current owner of the NFT, falling back to value set during setup on revert
+        try nftContract.ownerOf(tokenId) returns (address _owner) {
+            owner = _owner;
+        } catch (bytes memory) {
+            // Do nothing
+        }
+
+        for (uint256 i = 0; i < filteredOperators.length; i++) {
+            address operator = filteredOperators[i];
+            console2.log("Testing operator: ", operator);
+
+            // Try to set approval for the operator
+            vm.startPrank(owner);
+            try nftContract.setApprovalForAll(operator, true) {
+                // blocking approvals is not required, so continue to check transfers
+            } catch (bytes memory) {
+                // continue to test transfer methods, since marketplace approvals can be
+                // hard-coded into contracts
+            }
+
+            // also include per-token approvals as those may not be blocked
+            try nftContract.approve(operator, tokenId) {
+                // continue to check transfers
+            } catch (bytes memory) {
+                // continue to test transfer methods, since marketplace approvals can be
+                // hard-coded into contracts
+            }
+
+            vm.stopPrank();
+            // Ensure operator is not able to transfer the token
+            vm.startPrank(operator);
+            vm.expectRevert();
+            nftContract.safeTransferFrom(owner, address(1), tokenId);
+
+            vm.expectRevert();
+            nftContract.safeTransferFrom(owner, address(1), tokenId, "");
+
+            vm.expectRevert();
+            nftContract.transferFrom(owner, address(1), tokenId);
+            vm.stopPrank();
+        }
+    }
+}


### PR DESCRIPTION
The core functionality is implemented in OptionalOperatorFilterer.

Not enabled by default, Edition owners can call:
- setOperatorFilter(address) to subscribe to a particular list
- setOperatorFilter(0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6) to subscribe to OpenSea's default list
- setOperatorFilter(0) to disable operator filtering